### PR TITLE
feat: daemon version hashes

### DIFF
--- a/services/platform/daemon/communicate/client.go
+++ b/services/platform/daemon/communicate/client.go
@@ -223,7 +223,7 @@ func (c *client) osUpdateDiff(ctx context.Context) {
 
 func (c *client) currentDaemonVersion() {
 	c.logger.Info("current daemon version command")
-	daemonVersion, err := versioning.GetDaemonVersion(c.logger)
+	current, err := versioning.GetDaemonVersion(c.logger)
 	if err != nil {
 		c.logger.WithError(err).Error("failed to get current daemon version")
 		c.stream.Send(&v1.DaemonMessage{
@@ -236,9 +236,7 @@ func (c *client) currentDaemonVersion() {
 	} else {
 		err := c.stream.Send(&v1.DaemonMessage{
 			Message: &v1.DaemonMessage_CurrentDaemonVersion{
-				CurrentDaemonVersion: &v1.CurrentDaemonVersion{
-					Version: daemonVersion,
-				},
+				CurrentDaemonVersion: current,
 			},
 		})
 		if err != nil {

--- a/services/platform/daemon/go.mod
+++ b/services/platform/daemon/go.mod
@@ -8,7 +8,7 @@ go 1.22.5
 
 require (
 	connectrpc.com/connect v1.16.2
-	github.com/home-cloud-io/core/api v0.4.5
+	github.com/home-cloud-io/core/api v0.4.6
 	github.com/mackerelio/go-osstat v0.2.5
 	github.com/spf13/viper v1.18.2
 	github.com/steady-bytes/draft/pkg/chassis v0.3.0

--- a/services/platform/daemon/go.sum
+++ b/services/platform/daemon/go.sum
@@ -73,8 +73,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245 h1:Nyeelmxya
 github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0 h1:fPpQR1iGEVYjZ2OELvUHX600VAK5qmdnDEv3eXOwZUA=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0/go.mod h1:YHukhB04ChJsLHLJEUD6vjFyLX2L3dsX3wPBZcX4tmc=
-github.com/home-cloud-io/core/api v0.4.5 h1:98/WuxKrELxAYIqr/Yq3y7LVIzhbYotd2plwJl92iBk=
-github.com/home-cloud-io/core/api v0.4.5/go.mod h1:cfq/lv2YmpJGQ5sq1tADE18Y1ScGiYGpsBhimn78Tuk=
+github.com/home-cloud-io/core/api v0.4.6 h1:xCWF+hNBPPCfKcg2NNOPvKUfLg5LOKQ0QfS2CBR7HGs=
+github.com/home-cloud-io/core/api v0.4.6/go.mod h1:cfq/lv2YmpJGQ5sq1tADE18Y1ScGiYGpsBhimn78Tuk=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/services/platform/daemon/versioning/daemon.go
+++ b/services/platform/daemon/versioning/daemon.go
@@ -16,7 +16,11 @@ import (
 )
 
 const (
-	daemonNixFile = "/etc/nixos/home-cloud/daemon/default.nix"
+	daemonNixFile    = "/etc/nixos/home-cloud/daemon/default.nix"
+	versionPrefix    = "  version = \""
+	vendorHashPrefix = "  vendorHash = \""
+	srcHashPrefix    = "    hash = \""
+	nixLineSuffix    = "\";"
 )
 
 var (
@@ -24,34 +28,37 @@ var (
 	semverRegex = regexp.MustCompile(`(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`)
 )
 
-func GetDaemonVersion(logger chassis.Logger) (string, error) {
+func GetDaemonVersion(logger chassis.Logger) (*v1.CurrentDaemonVersion, error) {
 	f, err := os.Open(daemonNixFile)
 	if err != nil {
 		logger.WithError(err).Error("failed to read daemon nix file")
-		return "", err
+		return nil, err
 	}
 	defer f.Close()
 
-	var version string
+	current := &v1.CurrentDaemonVersion{}
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, "version =") {
-			version = semverRegex.FindString(line)
-			break
+		if strings.Contains(line, versionPrefix) {
+			current.Version = "v" + semverRegex.FindString(line)
+			continue
+		}
+		if strings.HasPrefix(line, vendorHashPrefix) {
+			current.VendorHash = strings.TrimSuffix(strings.TrimPrefix(line, vendorHashPrefix), nixLineSuffix)
+			continue
+		}
+		if strings.HasPrefix(line, srcHashPrefix) {
+			current.SrcHash = strings.TrimSuffix(strings.TrimPrefix(line, srcHashPrefix), nixLineSuffix)
+			continue
 		}
 	}
 
-	if version == "" {
-		return "", fmt.Errorf("failed to find daemon version")
-	}
-	version = "v" + version
-
-	if !semver.IsValid(version) {
-		return "", fmt.Errorf("invalid daemon version: %s", version)
+	if !semver.IsValid(current.Version) {
+		return nil, fmt.Errorf("invalid daemon version: %s", current.Version)
 	}
 
-	return version, nil
+	return current, nil
 }
 
 // TODO-RC2: There's a bit of a race condition with this right now. If you call GetOSVersionDiff and then call this

--- a/services/platform/server/go.mod
+++ b/services/platform/server/go.mod
@@ -12,7 +12,7 @@ require (
 	connectrpc.com/connect v1.16.2
 	github.com/containers/image/v5 v5.32.2
 	github.com/go-git/go-git/v5 v5.12.0
-	github.com/home-cloud-io/core/api v0.4.5
+	github.com/home-cloud-io/core/api v0.4.6
 	github.com/home-cloud-io/core/services/platform/operator v0.0.2
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/steady-bytes/draft/api v0.3.2

--- a/services/platform/server/go.sum
+++ b/services/platform/server/go.sum
@@ -170,8 +170,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245 h1:Nyeelmxya
 github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0 h1:fPpQR1iGEVYjZ2OELvUHX600VAK5qmdnDEv3eXOwZUA=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0/go.mod h1:YHukhB04ChJsLHLJEUD6vjFyLX2L3dsX3wPBZcX4tmc=
-github.com/home-cloud-io/core/api v0.4.5 h1:98/WuxKrELxAYIqr/Yq3y7LVIzhbYotd2plwJl92iBk=
-github.com/home-cloud-io/core/api v0.4.5/go.mod h1:cfq/lv2YmpJGQ5sq1tADE18Y1ScGiYGpsBhimn78Tuk=
+github.com/home-cloud-io/core/api v0.4.6 h1:xCWF+hNBPPCfKcg2NNOPvKUfLg5LOKQ0QfS2CBR7HGs=
+github.com/home-cloud-io/core/api v0.4.6/go.mod h1:cfq/lv2YmpJGQ5sq1tADE18Y1ScGiYGpsBhimn78Tuk=
 github.com/home-cloud-io/core/services/platform/operator v0.0.2 h1:cJLiFxEBUA7rj3oYAHX9TbLPCgGeGgLyEmIeCrwJuvA=
 github.com/home-cloud-io/core/services/platform/operator v0.0.2/go.mod h1:qhOt6mWdpGCpdWlxTIU3FJS8ybzRy66CoTCF3p5mMpI=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=


### PR DESCRIPTION
Forgot when working on auto updates to go back and resolve a TODO item about retrieving the daemon hashes (vendor and src) for the latest version to install. These are needed to perform upgrades and I'd been manually pushing them through the API to update the daemon up until now.

This PR adds logic to the server and daemon to process the version and source code/vendor hashes that define a full daemon version. The latest hashes are obtained by the server by evaluating git tags in the form of `daemon_VERSION_src_HASH` and `daemon_VERSION_vendor_HASH`. This is a bit clunky but gets us automatic updates for the daemon for now which is essential for RC1.