### PR TITLE
feat: web stream

### DIFF
--- a/services/platform/server/go.mod
+++ b/services/platform/server/go.mod
@@ -12,7 +12,7 @@ require (
 	connectrpc.com/connect v1.16.2
 	github.com/containers/image/v5 v5.32.2
 	github.com/go-git/go-git/v5 v5.12.0
-	github.com/home-cloud-io/core/api v0.4.9
+	github.com/home-cloud-io/core/api v0.4.10
 	github.com/home-cloud-io/core/services/platform/operator v0.0.2
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/steady-bytes/draft/api v0.3.2

--- a/services/platform/server/go.sum
+++ b/services/platform/server/go.sum
@@ -170,8 +170,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245 h1:Nyeelmxya
 github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0 h1:fPpQR1iGEVYjZ2OELvUHX600VAK5qmdnDEv3eXOwZUA=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0/go.mod h1:YHukhB04ChJsLHLJEUD6vjFyLX2L3dsX3wPBZcX4tmc=
-github.com/home-cloud-io/core/api v0.4.9 h1:HF1ADCT/Vp7GacAaMKth2k/UD+183Vg5y6gGKWElguY=
-github.com/home-cloud-io/core/api v0.4.9/go.mod h1:cfq/lv2YmpJGQ5sq1tADE18Y1ScGiYGpsBhimn78Tuk=
+github.com/home-cloud-io/core/api v0.4.10 h1:zSUWWAAB4/8gNapvqkUx3wnxqddvSilnxFX/qjsXW60=
+github.com/home-cloud-io/core/api v0.4.10/go.mod h1:cfq/lv2YmpJGQ5sq1tADE18Y1ScGiYGpsBhimn78Tuk=
 github.com/home-cloud-io/core/services/platform/operator v0.0.2 h1:cJLiFxEBUA7rj3oYAHX9TbLPCgGeGgLyEmIeCrwJuvA=
 github.com/home-cloud-io/core/services/platform/operator v0.0.2/go.mod h1:qhOt6mWdpGCpdWlxTIU3FJS8ybzRy66CoTCF3p5mMpI=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=

--- a/services/platform/server/system/commander.go
+++ b/services/platform/server/system/commander.go
@@ -20,12 +20,8 @@ type (
 )
 
 var (
-	com *commander
-)
-
-func Init() {
 	com = &commander{}
-}
+)
 
 func (c *commander) SetStream(stream *connect.BidiStream[dv1.DaemonMessage, dv1.ServerMessage]) error {
 	if c.stream != nil {

--- a/services/platform/server/system/server.go
+++ b/services/platform/server/system/server.go
@@ -25,7 +25,6 @@ type (
 var CurrentStats *v1.SystemStats
 
 func New(logger chassis.Logger, messages chan *v1.DaemonMessage) Server {
-	Init()
 	return &server{
 		logger:    logger,
 		messages:  messages,
@@ -42,7 +41,7 @@ func (h *server) Communicate(ctx context.Context, stream *connect.BidiStream[v1.
 	if err != nil {
 		return err
 	}
-	h.logger.Info("establishing stream")
+	h.logger.Info("establishing daemon stream")
 	for {
 		message, err := stream.Receive()
 		if err != nil {

--- a/services/platform/server/web/eventer.go
+++ b/services/platform/server/web/eventer.go
@@ -1,0 +1,43 @@
+package web
+
+import (
+	"fmt"
+
+	v1 "github.com/home-cloud-io/core/api/platform/server/v1"
+
+	"connectrpc.com/connect"
+)
+
+type (
+	Eventer interface {
+		SetStream(stream *connect.ServerStream[v1.ServerEvent]) error
+		CloseStream()
+	}
+
+	eventer struct {
+		stream *connect.ServerStream[v1.ServerEvent]
+	}
+)
+
+var (
+	events = &eventer{}
+)
+
+func (c *eventer) SetStream(stream *connect.ServerStream[v1.ServerEvent]) error {
+	if c.stream != nil {
+		return fmt.Errorf("stream already set")
+	}
+	c.stream = stream
+	return nil
+}
+
+func (c *eventer) CloseStream() {
+	c.stream = nil
+}
+
+func (c *eventer) Send(event *v1.ServerEvent) error {
+	if c.stream == nil {
+		return nil
+	}
+	return c.stream.Send(event)
+}


### PR DESCRIPTION
Implementing a basic unidirectional stream from the server to the web client. This can current push heartbeat, error, and app installed events.

Also updated the `InstallApp()` RPC method to return immediately and then push either an `Error` or `AppInstalled` event when the installation finishes.