### PR TITLE
fix: release child command on `nixos-rebuild switch`

### DIFF
--- a/services/platform/daemon/communicate/client.go
+++ b/services/platform/daemon/communicate/client.go
@@ -280,7 +280,6 @@ func (c *client) installOsUpdate(ctx context.Context) {
 		c.logger.WithError(err).Error("failed to install os update")
 		// TODO: return error to the server?
 	}
-	c.logger.Info("os update installed successfully")
 }
 
 func (c *client) setSystemImage(ctx context.Context, def *v1.SetSystemImageCommand) {

--- a/services/platform/daemon/communicate/client.go
+++ b/services/platform/daemon/communicate/client.go
@@ -275,7 +275,7 @@ func (c *client) changeDaemonVersion(ctx context.Context, def *v1.ChangeDaemonVe
 
 func (c *client) installOsUpdate(ctx context.Context) {
 	c.logger.Info("install os update command")
-	err := versioning.InstallOSUpdate(ctx, c.logger)
+	err := versioning.RebuildAndSwitchOS(ctx, c.logger)
 	if err != nil {
 		c.logger.WithError(err).Error("failed to install os update")
 		// TODO: return error to the server?

--- a/services/platform/daemon/execute/execute.go
+++ b/services/platform/daemon/execute/execute.go
@@ -70,47 +70,8 @@ func ExecuteCommand(ctx context.Context, cmd *exec.Cmd) error {
 // ExecuteCommandAndRelease will execute the given command and release all associated resources so that it will
 // continue to run even if the caller is terminated.
 func ExecuteCommandAndRelease(ctx context.Context, cmd *exec.Cmd) error {
-	// create a pipe for the output
-	cmdReader, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	// create a pipe for the error output
-	cmdErrReader, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	// scanner for output
-	scanner := bufio.NewScanner(cmdReader)
-	go func() {
-		for scanner.Scan() {
-			fmt.Println(scanner.Text())
-		}
-	}()
-
-	// scanner for error output
-	scannerErr := bufio.NewScanner(cmdErrReader)
-	go func() {
-		for scannerErr.Scan() {
-			fmt.Println(scannerErr.Text())
-		}
-	}()
-
-	// watch for done signal and kill process if received
-	go func() {
-		<-ctx.Done()
-		err := cmd.Process.Kill()
-		if err != nil {
-			// only error if not closed by user
-			if err.Error() != "signal: killed" && err.Error() != "os: process already finished" {
-				fmt.Println(err.Error())
-			}
-		}
-	}()
-
 	// start the command
-	err = cmd.Start()
+	err := cmd.Start()
 	if err != nil {
 		return err
 	}

--- a/services/platform/daemon/execute/execute.go
+++ b/services/platform/daemon/execute/execute.go
@@ -70,8 +70,47 @@ func ExecuteCommand(ctx context.Context, cmd *exec.Cmd) error {
 // ExecuteCommandAndRelease will execute the given command and release all associated resources so that it will
 // continue to run even if the caller is terminated.
 func ExecuteCommandAndRelease(ctx context.Context, cmd *exec.Cmd) error {
+	// create a pipe for the output
+	cmdReader, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	// create a pipe for the error output
+	cmdErrReader, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	// scanner for output
+	scanner := bufio.NewScanner(cmdReader)
+	go func() {
+		for scanner.Scan() {
+			fmt.Println(scanner.Text())
+		}
+	}()
+
+	// scanner for error output
+	scannerErr := bufio.NewScanner(cmdErrReader)
+	go func() {
+		for scannerErr.Scan() {
+			fmt.Println(scannerErr.Text())
+		}
+	}()
+
+	// watch for done signal and kill process if received
+	go func() {
+		<-ctx.Done()
+		err := cmd.Process.Kill()
+		if err != nil {
+			// only error if not closed by user
+			if err.Error() != "signal: killed" && err.Error() != "os: process already finished" {
+				fmt.Println(err.Error())
+			}
+		}
+	}()
+
 	// start the command
-	err := cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		return err
 	}

--- a/services/platform/daemon/execute/execute.go
+++ b/services/platform/daemon/execute/execute.go
@@ -67,6 +67,24 @@ func ExecuteCommand(ctx context.Context, cmd *exec.Cmd) error {
 	return nil
 }
 
+// ExecuteCommandAndRelease will execute the given command and release all associated resources so that it will
+// continue to run even if the caller is terminated.
+func ExecuteCommandAndRelease(ctx context.Context, cmd *exec.Cmd) error {
+	// start the command
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	// release any associated resources
+	err = cmd.Process.Release()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ExecuteCommandReturnStdout executes a command and returns the output of stdout as a string.
 // It does not print the output to the console. This can be used to get the output of a command.
 // It will not return until the command has completed or the context is cancelled.

--- a/services/platform/daemon/versioning/daemon.go
+++ b/services/platform/daemon/versioning/daemon.go
@@ -5,12 +5,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
 	v1 "github.com/home-cloud-io/core/api/platform/daemon/v1"
-	"github.com/home-cloud-io/core/services/platform/daemon/execute"
 	"github.com/steady-bytes/draft/pkg/chassis"
 	"golang.org/x/mod/semver"
 )
@@ -67,7 +65,6 @@ func GetDaemonVersion(logger chassis.Logger) (*v1.CurrentDaemonVersion, error) {
 // stateful logic which checks if a rollback is really needed. It's out of scope for RC1 but should be revisited later.
 func ChangeDaemonVersion(ctx context.Context, logger chassis.Logger, def *v1.ChangeDaemonVersionCommand) error {
 	var (
-		cmd       *exec.Cmd
 		err       error
 		replacers = []replacer{
 			func(line string) string {
@@ -98,14 +95,10 @@ func ChangeDaemonVersion(ctx context.Context, logger chassis.Logger, def *v1.Cha
 		return err
 	}
 
-	logger.Info("building nixos with new daemon version")
-	cmd = exec.Command("nixos-rebuild", "switch")
-	err = execute.ExecuteCommand(ctx, cmd)
+	err = RebuildAndSwitchOS(ctx, logger)
 	if err != nil {
-		logger.WithError(err).Error("failed to run `nixos-rebuild switch`")
 		return err
 	}
-	logger.Info("building nixos with new daemon version: DONE")
 
 	return nil
 }

--- a/services/platform/daemon/versioning/daemon.go
+++ b/services/platform/daemon/versioning/daemon.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	// source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-	semverRegex = regexp.MustCompile(`(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`)
+	semverRegex = regexp.MustCompile(`v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`)
 )
 
 func GetDaemonVersion(logger chassis.Logger) (*v1.CurrentDaemonVersion, error) {

--- a/services/platform/daemon/versioning/daemon.go
+++ b/services/platform/daemon/versioning/daemon.go
@@ -39,7 +39,7 @@ func GetDaemonVersion(logger chassis.Logger) (*v1.CurrentDaemonVersion, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.Contains(line, versionPrefix) {
-			current.Version = "v" + semverRegex.FindString(line)
+			current.Version = semverRegex.FindString(line)
 			continue
 		}
 		if strings.HasPrefix(line, vendorHashPrefix) {

--- a/services/platform/daemon/versioning/nix.go
+++ b/services/platform/daemon/versioning/nix.go
@@ -53,7 +53,7 @@ func GetOSVersionDiff(ctx context.Context, logger chassis.Logger) (string, error
 }
 
 // NOTE: must call this after calling GetOSVersionDiff if you want to perform a channel update.
-func InstallOSUpdate(ctx context.Context, logger chassis.Logger) error {
+func RebuildAndSwitchOS(ctx context.Context, logger chassis.Logger) error {
 	var (
 		cmd *exec.Cmd
 		err error
@@ -61,12 +61,11 @@ func InstallOSUpdate(ctx context.Context, logger chassis.Logger) error {
 
 	logger.Info("building and switching to updated nixos")
 	cmd = exec.Command("nixos-rebuild", "switch")
-	err = execute.ExecuteCommand(ctx, cmd)
+	err = execute.ExecuteCommandAndRelease(ctx, cmd)
 	if err != nil {
 		logger.WithError(err).Error("failed to run `nixos-rebuild switch`")
 		return err
 	}
-	logger.Info("building and switching to updated nixos: DONE")
 
 	return nil
 }
@@ -89,7 +88,7 @@ func SetTimeZone(ctx context.Context, logger chassis.Logger, timeZone string) er
 		return err
 	}
 
-	err = InstallOSUpdate(ctx, logger)
+	err = RebuildAndSwitchOS(ctx, logger)
 	if err != nil {
 		return err
 	}

--- a/services/platform/daemon/versioning/nix.go
+++ b/services/platform/daemon/versioning/nix.go
@@ -66,6 +66,7 @@ func RebuildAndSwitchOS(ctx context.Context, logger chassis.Logger) error {
 		logger.WithError(err).Error("failed to run `nixos-rebuild switch`")
 		return err
 	}
+	logger.Info("os update command issued to run in the background")
 
 	return nil
 }


### PR DESCRIPTION
Fixes a bug where the `daemon` is killed by systemd while executing the `nixos-rebuild switch` command and this also kills the child command so services stopped during the application of the OS update are not restarted. This causes the `daemon`, networking, k3s (any service needing an update really) to stay in a down state requiring a reboot of the machine to function again.

This PR fixes this issue by releasing the underlying process running the `nixos-rebuild switch` command so that when the `daemon` is stopped the underlying command will keep running. The drawback is that we lose the output/status of the underlying command so we have no way of knowing about the command's success or failure. We can revisit this issue later.