### PR TITLE
fix: remove mdns manifest file from daemon

### DIFF
--- a/services/platform/daemon/versioning/kubernetes.go
+++ b/services/platform/daemon/versioning/kubernetes.go
@@ -12,7 +12,6 @@ import (
 var (
 	systemKubernetesManifests = []string{
 		"/var/lib/rancher/k3s/server/manifests/draft.yaml",
-		"/var/lib/rancher/k3s/server/manifests/mdns.yaml",
 		"/var/lib/rancher/k3s/server/manifests/operator.yaml",
 		"/var/lib/rancher/k3s/server/manifests/server.yaml",
 	}


### PR DESCRIPTION
This file was removed from the OS with the mDNS changes to use Avahi and is so is causing a "no such file" error when attempting to update system containers.