### PR TITLE
feat: JSON-based Nix configuration

### DIFF
--- a/services/platform/daemon/communicate/upload.go
+++ b/services/platform/daemon/communicate/upload.go
@@ -34,7 +34,7 @@ func (c *client) uploadFile(_ context.Context, def *v1.UploadFileRequest) {
 		}
 
 		// make temporary chunk upload directory
-		err := os.MkdirAll(filepath.Join(host.ChunkPath, info.FileId), 0777)
+		err := os.MkdirAll(filepath.Join(host.ChunkPath(), info.FileId), 0777)
 		if err != nil {
 			log.WithError(err).Error("failed to create temp directory for file upload")
 			return
@@ -69,7 +69,7 @@ func (c *client) uploadFile(_ context.Context, def *v1.UploadFileRequest) {
 		})
 
 		// write chunk as temp file
-		fileName := filepath.Join(host.ChunkPath, meta.id, fmt.Sprintf("chunk.%d", chunk.Index))
+		fileName := filepath.Join(host.ChunkPath(), meta.id, fmt.Sprintf("chunk.%d", chunk.Index))
 		err := os.WriteFile(fileName, chunk.Data, 0666)
 		if err != nil {
 			log.WithError(err).Error("failed to write uploaded file chunk")
@@ -185,7 +185,7 @@ func (c *client) reconstructFile(logger chassis.Logger, metadata fileMeta) error
 	}
 
 	// remove the chunk file directory
-	err = os.Remove(filepath.Join(host.ChunkPath, metadata.id))
+	err = os.Remove(filepath.Join(host.ChunkPath(), metadata.id))
 	if err != nil {
 		logger.WithError(err).Error("failed to remove chunk directory")
 	}

--- a/services/platform/daemon/gen-nix-shas.sh
+++ b/services/platform/daemon/gen-nix-shas.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-VERSION=$(git rev-parse HEAD)
-REVISION=$(git rev-parse HEAD)
+VERSION=$1
+REVISION='services/platform/daemon/${version}'
+if [[ -z "$VERSION" ]]; then
+    VERSION=$(git rev-parse HEAD)
+    REVISION=$(git rev-parse HEAD)
+fi
 
-echo "version: $REVISION"
-sed -e "s/__VERSION__/$VERSION/g" -e "s/__REVISION__/$REVISION/g" default.nix.tmpl > tmp/default.nix
+echo "version: $VERSION"
+sed -e "s|__VERSION__|$VERSION|g" -e "s|__REVISION__|$REVISION|g" default.nix.tmpl > tmp/default.nix
 
 cd tmp/
 

--- a/services/platform/daemon/go.mod
+++ b/services/platform/daemon/go.mod
@@ -8,7 +8,7 @@ go 1.22.5
 
 require (
 	connectrpc.com/connect v1.16.2
-	github.com/home-cloud-io/core/api v0.4.24
+	github.com/home-cloud-io/core/api v0.4.25
 	github.com/mackerelio/go-osstat v0.2.5
 	github.com/spf13/viper v1.18.2
 	github.com/steady-bytes/draft/pkg/chassis v0.3.0

--- a/services/platform/daemon/go.sum
+++ b/services/platform/daemon/go.sum
@@ -73,8 +73,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245 h1:Nyeelmxya
 github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0 h1:fPpQR1iGEVYjZ2OELvUHX600VAK5qmdnDEv3eXOwZUA=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0/go.mod h1:YHukhB04ChJsLHLJEUD6vjFyLX2L3dsX3wPBZcX4tmc=
-github.com/home-cloud-io/core/api v0.4.24 h1:V1Bu25+x8HTtD1sjRKg5Kei04uEaiz6k+LmjtTeWCOE=
-github.com/home-cloud-io/core/api v0.4.24/go.mod h1:4G9DoubvZUuMFZOM63P6AOHyQ5Ulm9X2ilJ1EshIvjc=
+github.com/home-cloud-io/core/api v0.4.25 h1:TVaX8SJho7u1CikLPZafFo0DDvcKGPPhjbbByKjbgzs=
+github.com/home-cloud-io/core/api v0.4.25/go.mod h1:4G9DoubvZUuMFZOM63P6AOHyQ5Ulm9X2ilJ1EshIvjc=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/services/platform/daemon/host/daemon.go
+++ b/services/platform/daemon/host/daemon.go
@@ -27,7 +27,7 @@ var (
 )
 
 func GetDaemonVersion(logger chassis.Logger) (*v1.CurrentDaemonVersion, error) {
-	f, err := os.Open(DaemonNixFile)
+	f, err := os.Open(DaemonNixFile())
 	if err != nil {
 		logger.WithError(err).Error("failed to read daemon nix file")
 		return nil, err
@@ -89,7 +89,7 @@ func ChangeDaemonVersion(ctx context.Context, logger chassis.Logger, def *v1.Cha
 		}
 	)
 
-	err = LineByLineReplace(DaemonNixFile, replacers)
+	err = LineByLineReplace(DaemonNixFile(), replacers)
 	if err != nil {
 		logger.WithError(err).Error("failed to replace version")
 		return err

--- a/services/platform/daemon/host/kubernetes.go
+++ b/services/platform/daemon/host/kubernetes.go
@@ -9,20 +9,17 @@ import (
 	"github.com/steady-bytes/draft/pkg/chassis"
 )
 
-var (
-	systemKubernetesManifests = []string{
-		DraftManifestFile,
-		OperatorManifestFile,
-		ServerManifestFile,
-	}
-)
-
 func SetSystemImage(ctx context.Context, logger chassis.Logger, def *v1.SetSystemImageCommand) error {
 	var (
 		replacers = []Replacer{
 			func(line string) string {
 				return strings.ReplaceAll(line, def.CurrentImage, def.RequestedImage)
 			},
+		}
+		systemKubernetesManifests = []string{
+			DraftManifestFile(),
+			OperatorManifestFile(),
+			ServerManifestFile(),
 		}
 	)
 

--- a/services/platform/daemon/host/migrations.go
+++ b/services/platform/daemon/host/migrations.go
@@ -79,12 +79,12 @@ func (m migrator) Migrate() {
 
 	for _, l := range migrationsList {
 		complete := false
-		// for _, h := range history.Migrations {
-		// 	if l.Id == h.Id {
-		// 		complete = true
-		// 		break
-		// 	}
-		// }
+		for _, h := range history.Migrations {
+			if l.Id == h.Id {
+				complete = true
+				break
+			}
+		}
 		if !complete {
 			log := m.logger.WithFields(
 				chassis.Fields{
@@ -162,7 +162,7 @@ func m2(logger chassis.Logger) error {
 					},
 				},
 				BCache: BootConfigBCache{
-					Enable: true,
+					Enable: false,
 				},
 			},
 			NetworkingConfigFile(): NetworkingConfig{

--- a/services/platform/daemon/host/migrations.go
+++ b/services/platform/daemon/host/migrations.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -321,18 +320,8 @@ in
 		return err
 	}
 
-	err = Test(logger)
-	if err != nil {
-		return err
-	}
-
 	for path, config := range configs {
-		bytes, err := json.Marshal(config)
-		if err != nil {
-			return err
-		}
-
-		err = os.WriteFile(path, bytes, 0600)
+		err = WriteJsonFile(path, config, 0600)
 		if err != nil {
 			return err
 		}

--- a/services/platform/daemon/host/models.go
+++ b/services/platform/daemon/host/models.go
@@ -1,0 +1,112 @@
+package host
+
+type (
+	BootConfig struct {
+		Loader BootConfigLoader `json:"loader"`
+		BCache BootConfigBCache `json:"bcache"`
+	}
+	BootConfigLoader struct {
+		SystemdBoot BootConfigLoaderSystemdBoot `json:"systemd-boot"`
+	}
+	BootConfigLoaderSystemdBoot struct {
+		Enable bool `json:"enable"`
+	}
+	BootConfigBCache struct {
+		Enable bool `json:"enable"`
+	}
+
+	NetworkingConfig struct {
+		Hostname       string                         `json:"hostName"`
+		Domain         string                         `json:"domain"`
+		NetworkManager NetworkingConfigNetworkManager `json:"networkmanager"`
+		Wireless       NetworkingConfigWireless       `json:"wireless"`
+		Firewall       NetworkingConfigFirewall       `json:"firewall"`
+		NAT            NetworkingConfigNAT            `json:"nat"`
+		Wireguard      NetworkingConfigWireguard      `json:"wireguard"`
+	}
+	NetworkingConfigNetworkManager struct {
+		Enable bool `json:"enable"`
+	}
+	NetworkingConfigWireless struct {
+		Enable bool `json:"enable"`
+	}
+	NetworkingConfigFirewall struct {
+		Enable bool `json:"enable"`
+	}
+	NetworkingConfigNAT struct {
+		Enable             bool     `json:"enable"`
+		ExternalInterface  string   `json:"externalInterfaces,omitempty"`
+		InternalInterfaces []string `json:"internalInterfaces,omitempty"`
+	}
+	NetworkingConfigWireguard struct {
+		Interfaces map[string]WireguardInterface `json:"interfaces,omitempty"`
+	}
+	WireguardInterface struct {
+		IPs            []string        `json:"ips"`
+		ListenPort     uint32          `json:"listenPort"`
+		PrivateKeyFile string          `json:"privateKeyFile"`
+		Peers          []WireguardPeer `json:"peers"`
+	}
+	WireguardPeer struct {
+		PublicKey  string   `json:"publicKey"`
+		AllowedIPs []string `json:"allowedIPs"`
+	}
+
+	SecurityConfig struct {
+		Sudo SecurityConfigSudo `json:"sudo"`
+	}
+	SecurityConfigSudo struct {
+		WheelNeedsPassword bool `json:"wheelNeedsPassword"`
+	}
+
+	ServicesConfig struct {
+		Resolved ServicesConfigResolved `json:"resolved"`
+		K3s      ServicesConfigK3s      `json:"k3s"`
+		OpenSSH  ServicesConfigOpenSSH  `json:"openssh"`
+		Avahi    ServicesConfigAvahi    `json:"avahi"`
+	}
+	ServicesConfigResolved struct {
+		Enable  bool     `json:"enable"`
+		Domains []string `json:"domains"`
+	}
+	ServicesConfigK3s struct {
+		Enable     bool   `json:"enable"`
+		Role       string `json:"role"`
+		ExtraFlags string `json:"extraFlags"`
+	}
+	ServicesConfigOpenSSH struct {
+		Enable bool `json:"enable"`
+	}
+	ServicesConfigAvahi struct {
+		Enable   bool                       `json:"enable"`
+		IPv4     bool                       `json:"ipv4"`
+		IPv6     bool                       `json:"ipv6"`
+		NSSmDNS4 bool                       `json:"nssmdns4"`
+		Publish  ServicesConfigAvahiPublish `json:"publish"`
+	}
+	ServicesConfigAvahiPublish struct {
+		Enable       bool `json:"enable"`
+		Domain       bool `json:"domain"`
+		Addresses    bool `json:"addresses"`
+		UserServices bool `json:"userServices"`
+	}
+
+	TimeConfig struct {
+		TimeZone string `json:"timeZone"`
+	}
+
+	UsersConfig struct {
+		Users map[string]User `json:"users"`
+	}
+	User struct {
+		IsNormalUser bool        `json:"isNormalUser"`
+		ExtraGroups  []string    `json:"extraGroups"`
+		OpenSSH      UserOpenSSH `json:"openssh"`
+	}
+	UserOpenSSH struct {
+		AuthorizedKeys UserOpenSSHAuthorizedKeys `json:"authorizedKeys"`
+	}
+	UserOpenSSHAuthorizedKeys struct {
+		Keys []string `json:"keys"`
+	}
+)

--- a/services/platform/daemon/host/models.go
+++ b/services/platform/daemon/host/models.go
@@ -35,7 +35,7 @@ type (
 	}
 	NetworkingConfigNAT struct {
 		Enable             bool     `json:"enable"`
-		ExternalInterface  string   `json:"externalInterfaces,omitempty"`
+		ExternalInterface  string   `json:"externalInterface,omitempty"`
 		InternalInterfaces []string `json:"internalInterfaces,omitempty"`
 	}
 	NetworkingConfigWireguard struct {

--- a/services/platform/daemon/host/settings.go
+++ b/services/platform/daemon/host/settings.go
@@ -14,41 +14,6 @@ import (
 	"github.com/steady-bytes/draft/pkg/chassis"
 )
 
-type (
-	TimeConfig struct {
-		TimeZone string `json:"timeZone"`
-	}
-	ServicesConfig struct {
-		Resolved struct {
-			Enable  bool     `json:"enable"`
-			Domains []string `json:"domains"`
-		} `json:"resolved"`
-		K3s struct {
-			Enable     bool   `json:"enable"`
-			Role       string `json:"role"`
-			ExtraFlags string `json:"extraFlags"`
-		} `json:"k3s"`
-		OpenSSH struct {
-			Enable         bool `json:"enable"`
-			AuthorizedKeys struct {
-				Keys []string `json:"keys"`
-			} `json:"authorizedKeys"`
-		} `json:"openssh"`
-		Avahi struct {
-			Enable   bool `json:"enable"`
-			IPv4     bool `json:"ipv4"`
-			IPv6     bool `json:"ipv6"`
-			NSSmDNS4 bool `json:"nssmdns4"`
-			Publish  struct {
-				Enable       bool `json:"enable"`
-				Domain       bool `json:"domain"`
-				Addresses    bool `json:"addresses"`
-				UserServices bool `json:"userServices"`
-			}
-		} `json:"avahi"`
-	}
-)
-
 func SaveSettings(ctx context.Context, logger chassis.Logger, def *v1.SaveSettingsCommand) error {
 
 	err := setUserPassword(ctx, logger, def.AdminPassword)
@@ -76,7 +41,7 @@ func SaveSettings(ctx context.Context, logger chassis.Logger, def *v1.SaveSettin
 
 func setTimeZone(timeZone string) error {
 	// read
-	f, err := os.ReadFile(TimeConfigFile)
+	f, err := os.ReadFile(TimeConfigFile())
 	if err != nil {
 		return err
 	}
@@ -94,7 +59,7 @@ func setTimeZone(timeZone string) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(TimeConfigFile, b, 0777)
+	err = os.WriteFile(TimeConfigFile(), b, 0777)
 	if err != nil {
 		return err
 	}
@@ -102,33 +67,52 @@ func setTimeZone(timeZone string) error {
 }
 
 func setSSH(enableSSH bool, trustedSSHKeys []string) error {
-	// read
-	f, err := os.ReadFile(ServicesConfigFile)
+	// update ssh config
+
+	bytes, err := os.ReadFile(ServicesConfigFile())
 	if err != nil {
 		return err
 	}
-	c := ServicesConfig{}
-	err = json.Unmarshal(f, &c)
+	sshConfig := ServicesConfig{}
+	err = json.Unmarshal(bytes, &sshConfig)
 	if err != nil {
 		return err
 	}
 
-	// update
-	c.OpenSSH.Enable = enableSSH
+	sshConfig.OpenSSH.Enable = enableSSH
+
+	err = WriteJsonFile(ServicesConfigFile(), sshConfig, DefaultFileMode)
+	if err != nil {
+		return err
+	}
+
+	// update users config
+
+	bytes, err = os.ReadFile(UsersConfigFile())
+	if err != nil {
+		return err
+	}
+	usersConfig := UsersConfig{}
+	err = json.Unmarshal(bytes, &sshConfig)
+	if err != nil {
+		return err
+	}
+
 	if trustedSSHKeys == nil {
 		trustedSSHKeys = []string{}
 	}
-	c.OpenSSH.AuthorizedKeys.Keys = trustedSSHKeys
+	user, ok := usersConfig.Users["admin"]
+	if !ok {
+		return fmt.Errorf("admin user did not exist in config")
+	}
+	user.OpenSSH.AuthorizedKeys.Keys = trustedSSHKeys
+	usersConfig.Users["admin"] = user
 
-	// write
-	b, err := json.MarshalIndent(c, "", "  ")
+	err = WriteJsonFile(UsersConfigFile(), usersConfig, DefaultFileMode)
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(ServicesConfigFile, b, 0777)
-	if err != nil {
-		return err
-	}
+
 	return nil
 }
 

--- a/services/platform/daemon/host/settings.go
+++ b/services/platform/daemon/host/settings.go
@@ -93,7 +93,7 @@ func setSSH(enableSSH bool, trustedSSHKeys []string) error {
 		return err
 	}
 	usersConfig := UsersConfig{}
-	err = json.Unmarshal(bytes, &sshConfig)
+	err = json.Unmarshal(bytes, &usersConfig)
 	if err != nil {
 		return err
 	}

--- a/services/platform/daemon/host/stats.go
+++ b/services/platform/daemon/host/stats.go
@@ -68,11 +68,11 @@ func getMemoryStats(stats *v1.SystemStats) error {
 		return err
 	}
 	stats.Memory = &v1.MemoryStats{
-		TotalBytes:     uint32(memory.Total),
-		UsedBytes:      uint32(memory.Used),
-		CachedBytes:    uint32(memory.Cached),
-		FreeBytes:      uint32(memory.Free),
-		AvailableBytes: uint32(memory.Available),
+		TotalBytes:     memory.Total,
+		UsedBytes:      memory.Used,
+		CachedBytes:    memory.Cached,
+		FreeBytes:      memory.Free,
+		AvailableBytes: memory.Available,
 	}
 	return nil
 }
@@ -85,8 +85,8 @@ func getDriveStats(stats *v1.SystemStats, mounts []string) error {
 			return err
 		}
 		// Available blocks * size per block = available space in bytes
-		free := uint32(stat.Bavail * uint64(stat.Bsize))
-		total := uint32(stat.Blocks) * uint32(stat.Bsize)
+		free := stat.Bavail * uint64(stat.Bsize)
+		total := stat.Blocks * uint64(stat.Bsize)
 		stats.Drives[index] = &v1.DriveStats{
 			MountPoint: mountPoint,
 			TotalBytes: total,

--- a/services/platform/daemon/host/wireguard.go
+++ b/services/platform/daemon/host/wireguard.go
@@ -51,6 +51,10 @@ func AddWireguardInterface(ctx context.Context, logger chassis.Logger, def *v1.A
 			AllowedIPs: peer.AllowedIps,
 		})
 	}
+	// make sure map isn't nil
+	if config.Wireguard.Interfaces == nil {
+		config.Wireguard.Interfaces = make(map[string]WireguardInterface)
+	}
 	// add interface to existing map
 	config.Wireguard.Interfaces[def.Interface.Name] = WireguardInterface{
 		IPs:            def.Interface.Ips,

--- a/services/platform/daemon/init/main.go
+++ b/services/platform/daemon/init/main.go
@@ -14,6 +14,7 @@ var (
 		"auto-install/home-cloud/daemon/migrations.yaml": "./tmp/etc/home-cloud/migrations.yaml",
 		"auto-install/home-cloud/daemon/default.nix":     "./tmp/etc/nixos/home-cloud/daemon/default.nix",
 		"auto-install/configuration.nix":                 "./tmp/etc/nixos/configuration.nix",
+		"auto-install/vars.nix":                          "./tmp/etc/nixos/vars.nix",
 		"auto-install/home-cloud/draft.yaml":             "./tmp/var/lib/rancher/k3s/server/manifests/draft.yaml",
 		"auto-install/home-cloud/operator.yaml":          "./tmp/var/lib/rancher/k3s/server/manifests/operator.yaml",
 		"auto-install/home-cloud/server.yaml":            "./tmp/var/lib/rancher/k3s/server/manifests/server.yaml",

--- a/services/platform/daemon/init/main.go
+++ b/services/platform/daemon/init/main.go
@@ -14,6 +14,7 @@ var (
 		"auto-install/home-cloud/daemon/migrations.yaml": "./tmp/etc/home-cloud/migrations.yaml",
 		"auto-install/home-cloud/daemon/default.nix":     "./tmp/etc/nixos/home-cloud/daemon/default.nix",
 		"auto-install/configuration.nix":                 "./tmp/etc/nixos/configuration.nix",
+		"auto-install/hardware/generic.nix":              "./tmp/etc/nixos/hardware-configuration.nix",
 		"auto-install/vars.nix":                          "./tmp/etc/nixos/vars.nix",
 		"auto-install/home-cloud/draft.yaml":             "./tmp/var/lib/rancher/k3s/server/manifests/draft.yaml",
 		"auto-install/home-cloud/operator.yaml":          "./tmp/var/lib/rancher/k3s/server/manifests/operator.yaml",

--- a/services/platform/daemon/main.go
+++ b/services/platform/daemon/main.go
@@ -21,9 +21,6 @@ func main() {
 		WithRunner(mdns.Start).
 		WithRunner(migrator.Migrate)
 
-	// configure file paths before starting
-	host.ConfigureFilePaths(logger)
-
 	// start daemon runtime
 	runtime.Start()
 }

--- a/services/platform/server/go.mod
+++ b/services/platform/server/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/containers/image/v5 v5.32.2
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/google/uuid v1.6.0
-	github.com/home-cloud-io/core/api v0.4.24
+	github.com/home-cloud-io/core/api v0.4.25
 	github.com/home-cloud-io/core/services/platform/operator v0.0.2
 	github.com/netbirdio/netbird v0.30.3
 	github.com/robfig/cron/v3 v3.0.0

--- a/services/platform/server/go.sum
+++ b/services/platform/server/go.sum
@@ -204,8 +204,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245 h1:Nyeelmxya
 github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0 h1:fPpQR1iGEVYjZ2OELvUHX600VAK5qmdnDEv3eXOwZUA=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0/go.mod h1:YHukhB04ChJsLHLJEUD6vjFyLX2L3dsX3wPBZcX4tmc=
-github.com/home-cloud-io/core/api v0.4.24 h1:V1Bu25+x8HTtD1sjRKg5Kei04uEaiz6k+LmjtTeWCOE=
-github.com/home-cloud-io/core/api v0.4.24/go.mod h1:4G9DoubvZUuMFZOM63P6AOHyQ5Ulm9X2ilJ1EshIvjc=
+github.com/home-cloud-io/core/api v0.4.25 h1:TVaX8SJho7u1CikLPZafFo0DDvcKGPPhjbbByKjbgzs=
+github.com/home-cloud-io/core/api v0.4.25/go.mod h1:4G9DoubvZUuMFZOM63P6AOHyQ5Ulm9X2ilJ1EshIvjc=
 github.com/home-cloud-io/core/services/platform/operator v0.0.2 h1:cJLiFxEBUA7rj3oYAHX9TbLPCgGeGgLyEmIeCrwJuvA=
 github.com/home-cloud-io/core/services/platform/operator v0.0.2/go.mod h1:qhOt6mWdpGCpdWlxTIU3FJS8ybzRy66CoTCF3p5mMpI=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=

--- a/services/platform/server/web-client/package-lock.json
+++ b/services/platform/server/web-client/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "antd-demo",
-  "version": "0.1.0",
+  "name": "home-cloud-server-web-client",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "antd-demo",
-      "version": "0.1.0",
+      "name": "home-cloud-server-web-client",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/buf": "^1.47.2",
         "@bufbuild/protobuf": "1.10.0",
@@ -22,7 +23,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "antd": "^5.22.1",
-        "api": "https://gitpkg.vercel.app/home-cloud-io/core/api?api/v0.4.24",
+        "api": "https://gitpkg.vercel.app/home-cloud-io/core/api?api/v0.4.25",
         "install": "^0.13.0",
         "marked": "^15.0.0",
         "react": "^18.3.1",
@@ -3541,6 +3542,41 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.5.1.tgz",
+      "integrity": "sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==",
+      "peer": true,
+      "dependencies": {
+        "@module-federation/sdk": "0.5.1"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.5.1.tgz",
+      "integrity": "sha512-nfBedkoZ3/SWyO0hnmaxuz0R0iGPSikHZOAZ0N/dVSQaIzlffUo35B5nlC2wgWIc0JdMZfkwkjZRrnuuDIJbzg==",
+      "peer": true,
+      "dependencies": {
+        "@module-federation/runtime": "0.5.1",
+        "@module-federation/webpack-bundler-runtime": "0.5.1"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.5.1.tgz",
+      "integrity": "sha512-exvchtjNURJJkpqjQ3/opdbfeT2wPKvrbnGnyRkrwW5o3FH1LaST1tkiNviT6OXTexGaVc2DahbdniQHVtQ7pA==",
+      "peer": true
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.5.1.tgz",
+      "integrity": "sha512-mMhRFH0k2VjwHt3Jol9JkUsmI/4XlrAoBG3E0o7HoyoPYv1UFOWyqAflfANcUPgbYpvqmyLzDcO+3IT36LXnrA==",
+      "peer": true,
+      "dependencies": {
+        "@module-federation/runtime": "0.5.1",
+        "@module-federation/sdk": "0.5.1"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3910,6 +3946,172 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+    },
+    "node_modules/@rspack/binding": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.1.3.tgz",
+      "integrity": "sha512-fB1ziJ1UXO2P4ZDO+dviSNuxknUqrz6QQ6QGfpC+S1ClUy1HOhHXss/Yn78B/R9py6dlqZzmhmhz2d+XzFVApA==",
+      "peer": true,
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.1.3",
+        "@rspack/binding-darwin-x64": "1.1.3",
+        "@rspack/binding-linux-arm64-gnu": "1.1.3",
+        "@rspack/binding-linux-arm64-musl": "1.1.3",
+        "@rspack/binding-linux-x64-gnu": "1.1.3",
+        "@rspack/binding-linux-x64-musl": "1.1.3",
+        "@rspack/binding-win32-arm64-msvc": "1.1.3",
+        "@rspack/binding-win32-ia32-msvc": "1.1.3",
+        "@rspack/binding-win32-x64-msvc": "1.1.3"
+      }
+    },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-gpLUBMDAS/uEcnE+ODy1ILTeyp1oM4QCq8rRhKHuOfsIe1AZ9Mct59v2omIE/r+R4dnbJ0ikIpto9qJZ6P2u1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-m1G7SzkRfr1oLgghbAxUwj1J7hSKhtskQZiVeqe5tewKimFr6xLpKSTLTnEtlW0gdGNf1+dRMX/4kLMwhOdY7g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-MpOrO1oppxAm8J1ztNz6G5DG/oL9ZLHmIz9vYNV6PKnk+MPhCXqfhFmQ2hZm5VIVKuOobfYEJiDUqKg2MLg8gA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-PnUDC1JxT6a5hJW0hhJ9ubWk3R+nk7eLXyNaORHyQH4k8o89Zm5GYoKnDgO4eRy41NB9/aBJQJRGSRn0iAsZgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-+6JgyKXOp2QrHzlru95mge70tDkYlaY4NNE9xyrdj6PgTnM9cVPx4sLVhHC9+tWXaTFnccfEe9Tt6LjKnjHGaA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-X0TJTVL1Roqq/tvN26QO4u62x2xp5tE0dlhwhbeCHrBdgBzc+PHvcv/8lclRcq6lDPzceAgcnNX/+RbWg0DzKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-Lvpp5Q30YiPNkuOFPawp2al2CTWElPeG3X0E9LFIfPdVkLc/e2nkf5a6zSYtnbD2oaskzQIYN/k27fWqWWcVHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.1.3.tgz",
+      "integrity": "sha512-tC+xXcbTRX7l+NFnlGK8UhDIJrKma7S/MA1KDol23/I3Vw67EcaHDwG+q2v7uiJsxn9XooIOSCJhPKmUUfZNXg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-jeRaPJtsD/+m1QINgoDMA6D3kOcTwSHVmGSxR6fznLA5BKa76m8lewuALYxHHq9/qcgwJ4e6UtiwrO2JL3vxVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@rspack/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-LdM1mAlBtEh9ozbpyWVW5uuL+aJMjYqd531pH5/i/EPDKNrOLrQWVNMa2dh07qLwJZXoTFMf7LWA7QNsmBUPJg==",
+      "peer": true,
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.5.1",
+        "@rspack/binding": "1.1.3",
+        "@rspack/lite-tapable": "1.0.1",
+        "caniuse-lite": "^1.0.30001616"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/lite-tapable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
+      "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -5362,8 +5564,8 @@
     },
     "node_modules/api": {
       "version": "1.0.0",
-      "resolved": "https://gitpkg.vercel.app/home-cloud-io/core/api?api/v0.4.24",
-      "integrity": "sha512-cyeg9Dvp92hcYM3HWqbZTxaFSBbjWxrxCexqA1227LslFvZ6JTg+/6zgbVbevserQq0b9asBzbX3aXqkI2O6ZQ==",
+      "resolved": "https://gitpkg.vercel.app/home-cloud-io/core/api?api/v0.4.25",
+      "integrity": "sha512-KnUK6wHXLRi9gqP2NBE/efV/Jmeaf8Xvpgq3nJrogJ2y7Ug2z/NMdpEDQ8fTv7RjPKLsK0t+kJxX3qtByvXKfQ==",
       "license": "ISC",
       "dependencies": {
         "@bufbuild/buf": "^1.47.2",
@@ -5378,9 +5580,9 @@
       }
     },
     "node_modules/api/node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/services/platform/server/web-client/package.json
+++ b/services/platform/server/web-client/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "antd": "^5.22.1",
-    "api": "https://gitpkg.vercel.app/home-cloud-io/core/api?api/v0.4.24",
+    "api": "https://gitpkg.vercel.app/home-cloud-io/core/api?api/v0.4.25",
     "install": "^0.13.0",
     "marked": "^15.0.0",
     "react": "^18.3.1",

--- a/services/platform/server/web-client/src/pages/home/Home.tsx
+++ b/services/platform/server/web-client/src/pages/home/Home.tsx
@@ -102,12 +102,12 @@ export function DeviceDetails() {
         {!isLoading && !error && (
           <div>
             {`${formatBytes(
-              stats.drives[0].freeBytes
-            )} free out of ${formatBytes(stats.drives[0].totalBytes)} total`}
+              Number(stats.drives[0].freeBytes)
+            )} free out of ${formatBytes(Number(stats.drives[0].totalBytes))} total`}
             <Progress
               percent={formatPercentage(
-                stats.drives[0].freeBytes,
-                stats.drives[0].totalBytes
+                Number(stats.drives[0].freeBytes),
+                Number(stats.drives[0].totalBytes)
               )}
               percentPosition={{ align: 'start', type: 'outer' }}
             />


### PR DESCRIPTION
Added a migration to the daemon to shift the NixOS configuration to `.json` based files instead of `.nix` so that the daemon can manage the full configuration without resorting to the string parsing replacement methods. Also fixed up some bugs left over from the previous PR. Still need to go back and do the same type of change for k3s manifests.