### PR TITLE
fix: GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 # ignore generated protbuf files
 api/**/*.ts linguist-generated
 api/**/*.js linguist-generated
-# api/**.js linguist-generated
-# api/**.go linguist-generated
+api/**/*.go linguist-generated
 # ignore documentation
 docs/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # ignore generated protbuf files
-api/**.ts linguist-generated
-api/**.js linguist-generated
-api/**.go linguist-generated
+api/** linguist-generated
+# api/**.js linguist-generated
+# api/**.go linguist-generated
 # ignore documentation
 docs/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# ignore generated protbuf files
+api/**.ts linguist-generated
+api/**.js linguist-generated
+api/**.go linguist-generated
+# ignore documentation
+docs/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # ignore generated protbuf files
-api/** linguist-generated
+api/**/*.ts linguist-generated
+api/**/*.js linguist-generated
 # api/**.js linguist-generated
 # api/**.go linguist-generated
 # ignore documentation


### PR DESCRIPTION
GitHub Linguist was picking up all the generated files in `api/` and made it look like the repo was mostly TS/JS. This fixes the issue by ignoring generated files.