### PR TITLE
fix: daemon version bugs

### DIFF
--- a/services/platform/daemon/host/files.go
+++ b/services/platform/daemon/host/files.go
@@ -62,7 +62,7 @@ func NixosVarsFile() string {
 }
 
 func DaemonNixFile() string {
-	return FilePath(NixosRoot, "daemon/default.nix")
+	return FilePath(NixosRoot, "home-cloud/daemon/default.nix")
 }
 
 func NixosConfigsPath() string {


### PR DESCRIPTION
Fixes a bug where the daemon nix file path is incorrect causing errors when reading and updating the version. Also fixed the server to properly respond to the error returned by the daemon when this occurred. And finally, fixed a bad comparison which was pointer compare instead of attribute compare.