### PR TITLE
Write peer wireguard configuration to the interface

### DIFF
--- a/services/platform/daemon/communicate/client.go
+++ b/services/platform/daemon/communicate/client.go
@@ -164,6 +164,8 @@ func (c *client) listen(ctx context.Context) error {
 			go c.addWireguardInterface(ctx, message.GetAddWireguardInterface())
 		case *v1.ServerMessage_RemoveWireguardInterface:
 			go c.removeWireguardInterface(ctx, message.GetRemoveWireguardInterface())
+		case *v1.ServerMessage_AddWireguardPeer:
+			go c.addWireguardPeer(ctx, message.GetAddWireguardPeer().GetPeer())
 		default:
 			c.logger.WithField("message", message).Warn("unknown message type received")
 		}

--- a/services/platform/daemon/go.mod
+++ b/services/platform/daemon/go.mod
@@ -8,7 +8,7 @@ go 1.22.5
 
 require (
 	connectrpc.com/connect v1.16.2
-	github.com/home-cloud-io/core/api v0.4.26
+	github.com/home-cloud-io/core/api v0.8.1
 	github.com/mackerelio/go-osstat v0.2.5
 	github.com/spf13/viper v1.18.2
 	github.com/steady-bytes/draft/pkg/chassis v0.3.0

--- a/services/platform/daemon/go.sum
+++ b/services/platform/daemon/go.sum
@@ -73,8 +73,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245 h1:Nyeelmxya
 github.com/hashicorp/raft-boltdb v0.0.0-20231115180007-027066e4d245/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0 h1:fPpQR1iGEVYjZ2OELvUHX600VAK5qmdnDEv3eXOwZUA=
 github.com/hashicorp/raft-boltdb/v2 v2.3.0/go.mod h1:YHukhB04ChJsLHLJEUD6vjFyLX2L3dsX3wPBZcX4tmc=
-github.com/home-cloud-io/core/api v0.4.26 h1:4D9wX57j3wmbXow+fwon4n0iTaLm6cQBxosQxXJ/Ens=
-github.com/home-cloud-io/core/api v0.4.26/go.mod h1:4G9DoubvZUuMFZOM63P6AOHyQ5Ulm9X2ilJ1EshIvjc=
+github.com/home-cloud-io/core/api v0.8.1 h1:kXUMfIqh6zJ9ziV4iyeQzPDxjU64xyGrRprn0+GZWfA=
+github.com/home-cloud-io/core/api v0.8.1/go.mod h1:4G9DoubvZUuMFZOM63P6AOHyQ5Ulm9X2ilJ1EshIvjc=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/services/platform/daemon/host/wireguard.go
+++ b/services/platform/daemon/host/wireguard.go
@@ -143,3 +143,43 @@ func RemoveWireguardInterface(ctx context.Context, logger chassis.Logger, def *v
 func fullWireguardKeyPath(interfaceName string) string {
 	return filepath.Join(WireguardKeyPath(), interfaceName)
 }
+
+func AddWireguardPeer(ctx context.Context, logger chassis.Logger, peer *v1.WireguardPeer) error {
+	// read config
+	config := NetworkingConfig{}
+	f, err := os.ReadFile(NetworkingConfigFile())
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(f, &config)
+	if err != nil {
+		return err
+	}
+
+	// Adding peer to all `wg` interfaces. This will need to change when peering to other devices is built.
+	// currently the interface name is unknown
+	for _, v := range config.Wireguard.Interfaces {
+		v.Peers = append(v.Peers, WireguardPeer{
+			PublicKey:  peer.PublicKey,
+			AllowedIPs: peer.AllowedIps,
+		})
+	}
+
+	// write config
+	b, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(NetworkingConfigFile(), b, 0777)
+	if err != nil {
+		return err
+	}
+
+	err = RebuildAndSwitchOS(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
When the daemon receives a message to add a wireguard peer it's added to the nix configuration and then `Rebuilt` and `Switched`.

NOTE: The client is unaware of the wireguard interface to add the new peer to so by default it's being added to each `wg` interface. That will change when the device peering feature is created.