### PR TITLE
feat: NixOS automatic garbage collection

### DIFF
--- a/services/platform/daemon/host/files.go
+++ b/services/platform/daemon/host/files.go
@@ -74,6 +74,10 @@ func BootConfigFile() string {
 	return FilePath(nixosRoot, nixosConfigsPath, "boot.json")
 }
 
+func NixConfigFile() string {
+	return FilePath(nixosRoot, nixosConfigsPath, "nix.json")
+}
+
 func NetworkingConfigFile() string {
 	return FilePath(nixosRoot, nixosConfigsPath, "networking.json")
 }

--- a/services/platform/daemon/host/migrations.go
+++ b/services/platform/daemon/host/migrations.go
@@ -49,6 +49,12 @@ var (
 			Run:      m2,
 			Required: true,
 		},
+		{
+			Id:       "b5a63e29-4b35-48e9-b78f-8f3522225f6f",
+			Name:     "Add a nix.json config file which enables automatic, weekly garbage collection",
+			Run:      m3,
+			Required: true,
+		},
 	}
 )
 
@@ -333,6 +339,31 @@ in
 	}
 
 	err = os.WriteFile(NixosConfigFile(), []byte(nixConfigurationContents), 0600)
+	if err != nil {
+		return err
+	}
+
+	err = RebuildAndSwitchOS(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func m3(logger chassis.Logger) error {
+	var (
+		ctx           = context.Background()
+		nixConfigFile = NixConfig{
+			GC: NixConfigGC{
+				Automatic: true,
+				Dates:     "weekly",
+				Options:   "--delete-older-than 30d",
+			},
+		}
+	)
+
+	err := WriteJsonFile(NixConfigFile(), nixConfigFile, 0600)
 	if err != nil {
 		return err
 	}

--- a/services/platform/daemon/host/models.go
+++ b/services/platform/daemon/host/models.go
@@ -15,6 +15,15 @@ type (
 		Enable bool `json:"enable"`
 	}
 
+	NixConfig struct {
+		GC NixConfigGC `json:"gc"`
+	}
+	NixConfigGC struct {
+		Automatic bool   `json:"automatic"`
+		Dates     string `json:"dates"`
+		Options   string `json:"options"`
+	}
+
 	NetworkingConfig struct {
 		Hostname       string                         `json:"hostName"`
 		Domain         string                         `json:"domain"`


### PR DESCRIPTION
This PR enables a weekly NixOS garbage collection task which will remove any OS generations older than 30 days. This will help to keep down OS storage bloat as seen in #148.