### PR TITLE
fix: daemon Darwin build support

### DIFF
--- a/services/platform/daemon/host/stats.go
+++ b/services/platform/daemon/host/stats.go
@@ -6,8 +6,6 @@ import (
 
 	v1 "github.com/home-cloud-io/core/api/platform/daemon/v1"
 
-	"github.com/mackerelio/go-osstat/cpu"
-	"github.com/mackerelio/go-osstat/memory"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -41,40 +39,6 @@ func SystemStats(mounts []string) (*v1.SystemStats, error) {
 
 	stats.EndTime = timestamppb.Now()
 	return stats, nil
-}
-
-func getComputeStats(stats *v1.SystemStats) error {
-	before, err := cpu.Get()
-	if err != nil {
-		return err
-	}
-	time.Sleep(ComputeMeasurementDuration)
-	after, err := cpu.Get()
-	if err != nil {
-		return err
-	}
-	total := float32(after.Total - before.Total)
-	stats.Compute = &v1.ComputeStats{
-		UserPercent:   float32(after.User-before.User) / total * 100,
-		SystemPercent: float32(after.System-before.System) / total * 100,
-		IdlePercent:   float32(after.Idle-before.Idle) / total * 100,
-	}
-	return nil
-}
-
-func getMemoryStats(stats *v1.SystemStats) error {
-	memory, err := memory.Get()
-	if err != nil {
-		return err
-	}
-	stats.Memory = &v1.MemoryStats{
-		TotalBytes:     memory.Total,
-		UsedBytes:      memory.Used,
-		CachedBytes:    memory.Cached,
-		FreeBytes:      memory.Free,
-		AvailableBytes: memory.Available,
-	}
-	return nil
 }
 
 func getDriveStats(stats *v1.SystemStats, mounts []string) error {

--- a/services/platform/daemon/host/stats_darwin.go
+++ b/services/platform/daemon/host/stats_darwin.go
@@ -3,12 +3,18 @@
 
 package host
 
+// NOTE: the daemon is not intended to be run on darwin systems except for development
+// purposes. The below stats are limited on darwin builds only to enable build for local
+// development.
+
 import (
 	v1 "github.com/home-cloud-io/core/api/platform/daemon/v1"
 
 	"github.com/mackerelio/go-osstat/memory"
 )
 
+// NOTE: darwin builds do not support compute stats and so this will only ever
+// return zeros as values.
 func getComputeStats(stats *v1.SystemStats) error {
 	stats.Compute = &v1.ComputeStats{
 		UserPercent:   0,
@@ -18,6 +24,8 @@ func getComputeStats(stats *v1.SystemStats) error {
 	return nil
 }
 
+// NOTE: darwin builds do not support Available memory calls so this value
+// will only ever be zero.
 func getMemoryStats(stats *v1.SystemStats) error {
 	memory, err := memory.Get()
 	if err != nil {

--- a/services/platform/daemon/host/stats_darwin.go
+++ b/services/platform/daemon/host/stats_darwin.go
@@ -1,0 +1,34 @@
+//go:build darwin
+// +build darwin
+
+package host
+
+import (
+	v1 "github.com/home-cloud-io/core/api/platform/daemon/v1"
+
+	"github.com/mackerelio/go-osstat/memory"
+)
+
+func getComputeStats(stats *v1.SystemStats) error {
+	stats.Compute = &v1.ComputeStats{
+		UserPercent:   0,
+		SystemPercent: 0,
+		IdlePercent:   0,
+	}
+	return nil
+}
+
+func getMemoryStats(stats *v1.SystemStats) error {
+	memory, err := memory.Get()
+	if err != nil {
+		return err
+	}
+	stats.Memory = &v1.MemoryStats{
+		TotalBytes:     memory.Total,
+		UsedBytes:      memory.Used,
+		CachedBytes:    memory.Cached,
+		FreeBytes:      memory.Free,
+		// memory.Available not included on Darwin builds
+	}
+	return nil
+}

--- a/services/platform/daemon/host/stats_linux.go
+++ b/services/platform/daemon/host/stats_linux.go
@@ -1,0 +1,44 @@
+package host
+
+import (
+	"time"
+
+	v1 "github.com/home-cloud-io/core/api/platform/daemon/v1"
+
+	"github.com/mackerelio/go-osstat/cpu"
+	"github.com/mackerelio/go-osstat/memory"
+)
+
+func getComputeStats(stats *v1.SystemStats) error {
+	before, err := cpu.Get()
+	if err != nil {
+		return err
+	}
+	time.Sleep(ComputeMeasurementDuration)
+	after, err := cpu.Get()
+	if err != nil {
+		return err
+	}
+	total := float32(after.Total - before.Total)
+	stats.Compute = &v1.ComputeStats{
+		UserPercent:   float32(after.User-before.User) / total * 100,
+		SystemPercent: float32(after.System-before.System) / total * 100,
+		IdlePercent:   float32(after.Idle-before.Idle) / total * 100,
+	}
+	return nil
+}
+
+func getMemoryStats(stats *v1.SystemStats) error {
+	memory, err := memory.Get()
+	if err != nil {
+		return err
+	}
+	stats.Memory = &v1.MemoryStats{
+		TotalBytes:     memory.Total,
+		UsedBytes:      memory.Used,
+		CachedBytes:    memory.Cached,
+		FreeBytes:      memory.Free,
+		AvailableBytes: memory.Available,
+	}
+	return nil
+}


### PR DESCRIPTION
Since the daemon is only designed to be run on Linux systems, the OS stat collection was using Linux-only calls from the `github.com/mackerelio/go-osstat` module. This PR splits the stats collection into separate `linux` and `darwin` files so that the daemon can be built (for development only) on Mac systems.