### PR TITLE
fix: various fixes around upgrades and such

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_VERSION=1.25.3
-ARG ALPINE_VERSION=3.18
+ARG ALPINE_VERSION=3.23
 
 # Build web client (if needed)
 FROM node:22 AS web-client-builder

--- a/services/platform/operator/internal/controller/install_controller.go
+++ b/services/platform/operator/internal/controller/install_controller.go
@@ -736,8 +736,13 @@ func (r *InstallReconciler) apply(ctx context.Context, reader io.Reader) error {
 		applyOpts := metav1.ApplyOptions{FieldManager: "home-cloud-operator"}
 		_, err = dynamicClient.Resource(gvr).Apply(context.TODO(), obj.GetName(), obj, applyOpts)
 		if err != nil {
-			l.Error(err, "failed to apply object", "kind", obj.GetKind(), "name", obj.GetName())
-			return err
+			l.Error(err, "failed to apply object, attempting forced apply", "kind", obj.GetKind(), "name", obj.GetName())
+			applyOpts.Force = true
+			_, err = dynamicClient.Resource(gvr).Apply(context.TODO(), obj.GetName(), obj, applyOpts)
+			if err != nil {
+				l.Error(err, "failed to apply object with force, aborting", "kind", obj.GetKind(), "name", obj.GetName())
+				return err
+			}
 		}
 		l.V(1).Info("applied YAML for object", "kind", obj.GetKind(), "name", obj.GetName())
 	}

--- a/services/platform/operator/internal/controller/install_controller.go
+++ b/services/platform/operator/internal/controller/install_controller.go
@@ -41,6 +41,8 @@ type InstallReconciler struct {
 	DiscoveryClient *discovery.DiscoveryClient
 	Scheme          *runtime.Scheme
 	Config          *rest.Config
+	// global cancel function to shutdown the manager (useful for operator upgrades)
+	Cancel          context.CancelFunc
 }
 
 const (
@@ -118,9 +120,19 @@ func (r *InstallReconciler) reconcile(ctx context.Context, install *v1.Install) 
 		return err
 	}
 	if !install.Spec.Operator.Disable {
-		install.Status.Operator = &v1.OperatorStatus{
-			Image: install.Spec.Operator.Image,
-			Tag:   install.Spec.Operator.Tag,
+		if install.Spec.Operator.Tag != install.Status.Operator.Tag ||
+			install.Spec.Operator.Image != install.Status.Operator.Image {
+			install.Status.Operator = &v1.OperatorStatus{
+				Image: install.Spec.Operator.Image,
+				Tag:   install.Spec.Operator.Tag,
+			}
+			err := r.Status().Update(ctx, install)
+			if err != nil {
+				return err
+			}
+
+			// shutdown if operator has updated so that the new replica can take over
+			r.Cancel()
 		}
 	} else {
 		install.Status.Operator = nil

--- a/services/platform/operator/main.go
+++ b/services/platform/operator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -48,11 +49,16 @@ func main() {
 	logr := logger.NewLogger(log.WithFields(nil))
 	ctrl.SetLogger(logr)
 
+	globalCtx, globalCancel := context.WithCancel(ctrl.SetupSignalHandler())
+
 	// configure manager
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Logger:                 logr,
-		Scheme:                 scheme,
-		HealthProbeBindAddress: ":" + chassis.GetConfig().GetString("service.network.bind_port"),
+		Logger:                        logr,
+		Scheme:                        scheme,
+		HealthProbeBindAddress:        ":" + chassis.GetConfig().GetString("service.network.bind_port"),
+		LeaderElection:                true,
+		LeaderElectionID:              "operator.home-cloud.io",
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		log.WithError(err).Error("failed to create manager")
@@ -80,6 +86,7 @@ func main() {
 		DiscoveryClient: discoveryClient,
 		Scheme:          mgr.GetScheme(),
 		Config:          mgr.GetConfig(),
+		Cancel:          globalCancel,
 	}).SetupWithManager(mgr); err != nil {
 		log.WithField("controller", "Install").WithError(err).Error("failed to create controller")
 		os.Exit(1)
@@ -97,7 +104,7 @@ func main() {
 
 	// start manager
 	log.Warn("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(globalCtx); err != nil {
 		log.WithError(err).Error("problem running manager")
 		os.Exit(1)
 	}

--- a/services/platform/operator/resources/resources.go
+++ b/services/platform/operator/resources/resources.go
@@ -52,5 +52,14 @@ resources:
 				Hostname: "home-cloud.local",
 			},
 		},
+		Status: v1.InstallStatus{
+			GatewayAPI: &v1.GatewayAPIStatus{},
+			Istio: &v1.IstioStatus{},
+			Server: &v1.ServerStatus{},
+			MDNS: &v1.MDNSStatus{},
+			Tunnel: &v1.TunnelStatus{},
+			Operator: &v1.OperatorStatus{},
+			Daemon: &v1.DaemonStatus{},
+		},
 	}
 )

--- a/services/platform/server/system/device.go
+++ b/services/platform/server/system/device.go
@@ -141,6 +141,9 @@ func (c *controller) SetServerSettings(ctx context.Context, logger chassis.Logge
 		logger.WithError(err).Error("failed to get install")
 		return err
 	}
+	if install.Spec.Settings == nil {
+		install.Spec.Settings = &opv1.SettingsSpec{}
+	}
 
 	if settings.AutoUpdateApps {
 		c.actl.AutoUpdate(ctx, logger, hstrings.Default(settings.AutoUpdateAppsSchedule, apps.DefaultAutoUpdateAppsSchedule))

--- a/services/platform/server/system/os.go
+++ b/services/platform/server/system/os.go
@@ -57,9 +57,10 @@ func (c *controller) EnableWireguard(ctx context.Context, logger chassis.Logger)
 				logger.WithError(err).Error("failed to generate wireguard private key")
 				return err
 			}
+		} else {
+			logger.WithError(err).Error("failed to get wireguard server secret")
+			return err
 		}
-		logger.WithError(err).Error("failed to get wireguard server secret")
-		return err
 	} else {
 		// read existing secret from secret
 		key, err = wgtypes.ParseKey(string(wireguardServerSecret.Data["privateKey"]))


### PR DESCRIPTION
Misc fixes for upgrades and API changes:
- leader election is back with clean exit on operator upgrades
- force apply retry logic in operator (this overwrites FieldManager on CRDs that are installed with kubectl initially)
- nil pointer fixes
- bad Wireguard init logic
- updated alpine (needed newer iptables and was just a super old version)