### PR TITLE
fix: operator panics on app persistence

### DIFF
--- a/services/platform/operator/controller/apps/persistence.go
+++ b/services/platform/operator/controller/apps/persistence.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"dario.cat/mergo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,7 @@ import (
 	dv1 "github.com/home-cloud-io/core/api/platform/daemon/v1"
 	v1 "github.com/home-cloud-io/core/services/platform/operator/api/v1"
 	"github.com/home-cloud-io/core/services/platform/operator/controller/daemon"
+	"github.com/home-cloud-io/core/services/platform/operator/controller/installs/resources"
 )
 
 // TODO: think about making this pluggable for different types of PV sources (ie. not just host path)
@@ -30,11 +32,18 @@ func (r *AppReconciler) createPersistence(ctx context.Context, p AppPersistence,
 		storageClassName = "manual"
 	)
 
+	// get current install config
 	install := &v1.Install{}
 	err := r.Client.Get(ctx, types.NamespacedName{
 		Name:      "install",
 		Namespace: "home-cloud-system",
 	}, install)
+	if err != nil {
+		return err
+	}
+
+	// set defaults: any values set on the resource will override the defaults
+	err = mergo.Merge(install, resources.DefaultInstall)
 	if err != nil {
 		return err
 	}

--- a/services/platform/operator/controller/installs/resources/operator.go
+++ b/services/platform/operator/controller/installs/resources/operator.go
@@ -173,6 +173,7 @@ var (
 					},
 				},
 			},
+			// TODO: remove this from operator.go so that operator can be installed with GatewayAPI
 			&gwv1.HTTPRoute{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "gateway.networking.k8s.io/v1",

--- a/services/platform/operator/controller/installs/resources/resources.go
+++ b/services/platform/operator/controller/installs/resources/resources.go
@@ -16,6 +16,7 @@ var (
 			GatewayAPI: &v1.GatewayAPISpec{},
 			Istio: &v1.IstioSpec{
 				Namespace:          "istio-system",
+				// TODO: do this through a separate Gateway resources so that people can run without Istio
 				IngressGatewayName: "ingress-gateway",
 				Base:               &v1.BaseSpec{},
 				Istiod: &v1.IstiodSpec{

--- a/services/platform/tunnel/go.mod
+++ b/services/platform/tunnel/go.mod
@@ -1,4 +1,4 @@
-module github.com/home-cloud-io/services/platform/tunnel
+module github.com/home-cloud-io/core/services/platform/tunnel
 
 go 1.25.3
 

--- a/services/platform/tunnel/main.go
+++ b/services/platform/tunnel/main.go
@@ -16,8 +16,8 @@ import (
 
 	v1 "github.com/home-cloud-io/core/services/platform/operator/api/v1"
 	"github.com/home-cloud-io/core/services/platform/operator/logger"
-	"github.com/home-cloud-io/services/platform/tunnel/stun"
-	"github.com/home-cloud-io/services/platform/tunnel/wireguard"
+	"github.com/home-cloud-io/core/services/platform/tunnel/stun"
+	"github.com/home-cloud-io/core/services/platform/tunnel/wireguard"
 )
 
 var (

--- a/services/platform/tunnel/wireguard/controller.go
+++ b/services/platform/tunnel/wireguard/controller.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "github.com/home-cloud-io/core/services/platform/operator/api/v1"
-	"github.com/home-cloud-io/services/platform/tunnel/stun"
+	"github.com/home-cloud-io/core/services/platform/tunnel/stun"
 )
 
 type WireguardReconciler struct {

--- a/services/platform/tunnel/wireguard/locator.go
+++ b/services/platform/tunnel/wireguard/locator.go
@@ -16,8 +16,8 @@ import (
 	lv1 "github.com/home-cloud-io/core/api/platform/locator/v1"
 	sdConnect "github.com/home-cloud-io/core/api/platform/locator/v1/v1connect"
 	v1 "github.com/home-cloud-io/core/services/platform/operator/api/v1"
-	"github.com/home-cloud-io/services/platform/tunnel/stun"
-	"github.com/home-cloud-io/services/platform/tunnel/wireguard/encryption"
+	"github.com/home-cloud-io/core/services/platform/tunnel/stun"
+	"github.com/home-cloud-io/core/services/platform/tunnel/wireguard/encryption"
 )
 
 type LocatorClient struct {


### PR DESCRIPTION
Fixing a panic on app persistence when the daemon config is not set on the `Install` CR.

Also fixed the module name of `tunnel` to have the full path.