### PR TITLE
fix: disable arm64 image builds

### DIFF
--- a/.github/workflows/services-cd.yml
+++ b/.github/workflows/services-cd.yml
@@ -12,7 +12,8 @@ on:
 
 env:
   REGISTRY: ${{ vars.REGISTRY || 'ghcr.io' }}
-  TARGET_PLATFORMS: linux/amd64,linux/arm64
+  # TODO: build arm64 too
+  TARGET_PLATFORMS: linux/amd64
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
There's an issue with building the web client in Docker that is breaking ARM builds. Will come back to this later.